### PR TITLE
Fix username casing during registration

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -107,18 +107,21 @@ export function AuthProvider({ children }) {
     try {
       const result = await createUserWithEmailAndPassword(auth, email, password);
       const { user } = result;
-      
+
+      // Normalize username to lowercase for consistent logins
+      const normalizedUsername = username.trim().toLowerCase();
+
       // Ensure profile photo is always set to default, never null
       const profilePhotoToSave = DEFAULT_PROFILE_PHOTO;
       
       console.log(`🖼️ [AuthContext] Creating user ${user.uid} with default profile photo: ${profilePhotoToSave}`);
       
       // Create user profile in Firestore with only the 15 required fields
-      await createUserDocument(user.uid, {
-        uid: user.uid,
-        email,
-        username,
-        displayName: username,
+        await createUserDocument(user.uid, {
+          uid: user.uid,
+          email,
+          username: normalizedUsername,
+          displayName: username,
         phoneNumber: '',
         gender: '',
         dateOfBirth: '',

--- a/src/pages/Auth/Register.js
+++ b/src/pages/Auth/Register.js
@@ -106,12 +106,13 @@ export default function Register() {
     
     try {
       // Register user with Firebase Auth (always as client in new architecture)
-      const user = await signup(values.email, values.password, values.username, USER_ROLES.CLIENT);
+      const normalizedUsername = values.username.trim().toLowerCase();
+      const user = await signup(values.email, values.password, normalizedUsername, USER_ROLES.CLIENT);
       
       // Create complete user profile with multi-role architecture
       await createUserProfile(user.uid, {
         displayName: values.fullName,
-        username: values.username,
+        username: normalizedUsername,
         // Multi-role fields
         roles: [USER_ROLES.CLIENT],
         activeRole: USER_ROLES.CLIENT,


### PR DESCRIPTION
## Summary
- normalize usernames to lowercase in AuthContext signup
- ensure registration page passes a lowercased username to signup and profile creation

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d6bbd9d8833395ba522db823433a